### PR TITLE
add null check for GooglePayButtonConstants native module

### DIFF
--- a/src/GooglePayButton.jsx
+++ b/src/GooglePayButton.jsx
@@ -19,7 +19,7 @@ import {NativeModules, requireNativeComponent, TouchableOpacity, StyleSheet} fro
 
 const NativeGooglePayButton = requireNativeComponent('GooglePayButton')
 
-const GooglePayButtonConstants = NativeModules.GooglePayButtonConstants.getConstants();
+const GooglePayButtonConstants = NativeModules.GooglePayButtonConstants?.getConstants();
 
 const GooglePayButton = ({
     onPress,


### PR DESCRIPTION
When adding the package on iOS without really using it, you get an `cannot find getConstants() of null` error. Adding optional chaining prevents the error.