### PR TITLE
add namespace to build.gradle for AGP > 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,11 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.makepayment"
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {


### PR DESCRIPTION
Support AGP >7 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671