### PR TITLE
fix type mismatch when calling promise.resolve() during isReadyToPay

### DIFF
--- a/android/src/main/java/com/makepayment/MakePaymentModule.kt
+++ b/android/src/main/java/com/makepayment/MakePaymentModule.kt
@@ -48,9 +48,9 @@ class MakePaymentModule(reactContext: ReactApplicationContext) :
                         // Received response from Google Pay API - resolve the current promise.
                         Activity.RESULT_OK -> {
                             try {
-                                intent?.let { intent ->
+                                intent?.let { i ->
                                     val paymentData = Convert.jsonStringToMap(
-                                        PaymentData.getFromIntent(intent)!!.toJson()
+                                        PaymentData.getFromIntent(i)!!.toJson()
                                     )
                                     loadPaymentDataPromise.resolve(paymentData)
                                 }
@@ -96,7 +96,7 @@ class MakePaymentModule(reactContext: ReactApplicationContext) :
             if (completedTask.isSuccessful) {
                 promise.resolve(completedTask.result)
             } else {
-                promise.reject(completedTask.exception)
+                promise.reject(E_UNABLE_TO_DETERMINE_GOOGLE_PAY_READINESS, completedTask.exception)
             }
         }
     }
@@ -131,6 +131,7 @@ class MakePaymentModule(reactContext: ReactApplicationContext) :
     companion object {
         private const val NAME = "MakePayment"
         private const val LOAD_PAYMENT_DATA_REQUEST_CODE = 991
+        private const val E_UNABLE_TO_DETERMINE_GOOGLE_PAY_READINESS = "E_UNABLE_TO_DETERMINE_GOOGLE_PAY_READINESS"
 
         private fun createPaymentsClient(context: ReactApplicationContext): PaymentsClient {
             Log.d(NAME, "createPaymentsClient env=" + BuildConfig.GOOGLE_PAY_ENVIRONMENT)


### PR DESCRIPTION
- React Native changed the implementation from [`public fun reject(throwable: Throwable?)`](https://github.com/facebook/react-native/pull/44587/files#diff-74cbd5a9d82e4c21dbc37dd72a92e31542e574dc6425d2454c3ce53e71e08bbeR56) to [`public fun reject(throwable: Throwable)`](https://github.com/facebook/react-native/blob/8c06f57860278cd4ff4a03bf182d22a27fcd0779/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.kt#L56)
- Introduced an error code and switched to [`public fun reject(code: String, throwable: Throwable?)`](https://github.com/facebook/react-native/blob/8c06f57860278cd4ff4a03bf182d22a27fcd0779/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.kt#L39) as this sill allows an optional throwable.
- [minor] also fixed one occasion of variable shadowing

Fixes #36 



