### PR TITLE
fix: (RN v0.79 compatibility)Convert ReadableMap and ReadableArray to JSON Objects Safely to avoid type mismatch error with Kotlin v2.0 

### DIFF
--- a/android/src/main/java/com/makepayment/Convert.kt
+++ b/android/src/main/java/com/makepayment/Convert.kt
@@ -41,8 +41,8 @@ object Convert {
                 ReadableType.Boolean -> jsonObject.put(key, readableMap.getBoolean(key))
                 ReadableType.Number -> jsonObject.put(key, readableMap.getDouble(key))
                 ReadableType.String -> jsonObject.put(key, readableMap.getString(key))
-                ReadableType.Map -> jsonObject.put(key, mapToJson(readableMap.getMap(key)!!))
-                ReadableType.Array -> jsonObject.put(key, arrayToJson(readableMap.getArray(key)!!))
+                ReadableType.Map -> jsonObject.put(key, readableMap.getMap(key)?.let { mapToJson(it) } ?: JSONObject.NULL)
+                ReadableType.Array -> jsonObject.put(key, readableMap.getArray(key)?.let { arrayToJson(it) } ?: JSONObject.NULL)
             }
         }
         return jsonObject
@@ -53,12 +53,12 @@ object Convert {
         val array = JSONArray()
         for (i in 0 until readableArray.size()) {
             when (readableArray.getType(i)) {
-                ReadableType.Null -> {}
+                ReadableType.Null -> array.put(JSONObject.NULL)
                 ReadableType.Boolean -> array.put(readableArray.getBoolean(i))
                 ReadableType.Number -> array.put(readableArray.getDouble(i))
                 ReadableType.String -> array.put(readableArray.getString(i))
-                ReadableType.Map -> array.put(mapToJson(readableArray.getMap(i)))
-                ReadableType.Array -> array.put(arrayToJson(readableArray.getArray(i)))
+                ReadableType.Map -> array.put(readableArray.getMap(i)?.let { mapToJson(it) } ?: JSONObject.NULL)
+                ReadableType.Array -> array.put(readableArray.getArray(i)?.let { arrayToJson(it) } ?: JSONObject.NULL)
             }
         }
         return array


### PR DESCRIPTION
**Describe the changes proposed**
This PR introduces two utility functions mapToJson and arrayToJson to convert React Native's ReadableMap and ReadableArray into standard JSONObject and JSONArray. The implementation ensures null-safety and avoids type mismatch issues when adding nested values to JSON structures.

✅ **Key Updates:**
Handled null values explicitly using ?: JSONObject.NULL to avoid type mismatch errors in put() calls.

Used Kotlin's let for clean null-safe transformation of nested maps and arrays.
use Elvis operator (?:) to default to JSONObject.NULL when the .getMap() or .getArray() returns null. Used ?: JSONObject.NULL after .let to handle null values safely.

Added JSONObject.NULL to ReadableType.Null case in arrayToJson().
Added support for all ReadableType values: Null, Boolean, Number, String, Map, and Array.

These functions will be used in bridging logic where dynamic data from JS is transformed into structured JSON for native handling.

This should eliminate the type mismatch error and make the functions robust for all cases. Let me know if you want to include type-safe logging or error handling too.

**Screenshots / Videos**
<img width="609" alt="Screenshot 2025-06-30 at 12 34 44 PM" src="https://github.com/user-attachments/assets/c757ead1-3cd4-4b1b-891a-68da788d62ad" />

**Additional context**
Getting this error( type mismatch error)  with Kotlin version 2.0+

Ref: https://github.com/google-pay/react-native-make-payment/issues/49
