### PR TITLE
fix: handle null checks for kotlin v2 and above

### DIFF
--- a/android/src/main/java/com/makepayment/Convert.kt
+++ b/android/src/main/java/com/makepayment/Convert.kt
@@ -43,11 +43,15 @@ object Convert {
                 ReadableType.String -> jsonObject.put(key, readableMap.getString(key))
                 ReadableType.Map -> {
                     val map = readableMap.getMap(key)
-                    jsonObject.put(key, map?.let { mapToJson(it) } ?: JSONObject.NULL)
+                    if (map != null) {
+                        jsonObject.put(key, map?.let { mapToJson(it) } ?: JSONObject.NULL)
+                    }
                 }
                 ReadableType.Array -> {
                     val array = readableMap.getArray(key)
-                    jsonObject.put(key, array?.let { arrayToJson(it) } ?: JSONObject.NULL)
+                    if (array != null) {
+                        jsonObject.put(key, array?.let { arrayToJson(it) } ?: JSONObject.NULL)
+                    }
                 }
             }
         }
@@ -71,11 +75,15 @@ object Convert {
                 }
                 ReadableType.Map -> {
                     val map = readableArray.getMap(i)
-                    array.put(map?.let { mapToJson(it) } ?: JSONObject.NULL)
+                    if (map != null) {
+                        array.put(map?.let { mapToJson(it) } ?: JSONObject.NULL)
+                    }
                 }
                 ReadableType.Array -> {
                     val nestedArray = readableArray.getArray(i)
-                    array.put(nestedArray?.let { arrayToJson(it) } ?: JSONObject.NULL)
+                    if (nestedArray != null) {
+                        array.put(nestedArray?.let { arrayToJson(it) } ?: JSONObject.NULL)
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Describe the changes proposed**
Add null checks for map and array retrieval as this is broken in Kotlin versions above 2.0.0

**Additional context**
Related issue  #49