### PR TITLE
fix: type `GooglePayButtonConstants`

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,7 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
+    "@google/react-native-make-payment": "workspace:^",
     "@react-native-community/cli": "18.0.0",
     "@react-native-community/cli-platform-android": "18.0.0",
     "@react-native-community/cli-platform-ios": "18.0.0",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -150,7 +150,6 @@ const styles = StyleSheet.create({
   text: {
     padding: 20,
     fontFamily: 'monospace',
-    whiteSpace: 'pre',
     fontSize: 13,
     textAlign: 'center',
   },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, ScrollView, StyleSheet, NativeModules } from 'react-native';
+import { Text, ScrollView, StyleSheet } from 'react-native';
 import { 
   NAME, VERSION, GOOGLE_PAY_PMI, 
   PaymentRequest, GooglePayButton, GooglePayButtonConstants

--- a/src/specs/NativeGooglePayButtonConstantsModule.ts
+++ b/src/specs/NativeGooglePayButtonConstantsModule.ts
@@ -1,8 +1,25 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry, NativeModules } from 'react-native';
 
+export interface Constants {
+  Themes: {
+    Dark: number;
+    Light: number;
+  };
+  Types: {
+    Buy: number;
+    Book: number;
+    Checkout: number;
+    Donate: number;
+    Order: number;
+    Pay: number;
+    Subscribe: number;
+    Plain: number;
+  };
+}
+
 export interface Spec extends TurboModule {
-  loadConstants(): { string: { string: number } };
+  loadConstants(): Constants;
 }
 
 export default (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,7 +1678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google/react-native-make-payment@workspace:.":
+"@google/react-native-make-payment@workspace:., @google/react-native-make-payment@workspace:^":
   version: 0.0.0-use.local
   resolution: "@google/react-native-make-payment@workspace:."
   dependencies:
@@ -8687,6 +8687,7 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/runtime": "npm:^7.25.0"
+    "@google/react-native-make-payment": "workspace:^"
     "@react-native-community/cli": "npm:18.0.0"
     "@react-native-community/cli-platform-android": "npm:18.0.0"
     "@react-native-community/cli-platform-ios": "npm:18.0.0"


### PR DESCRIPTION
Hey @stephenmcd 

As mentioned in #58, the typings for the `GooglePayButtonConstants` are broken leading to us having to use numeric constants instead.

This PR also fixes the example app by ensuring `@google/react-native-make-payment` is imported correctly.

Fixes #58 