### PR TITLE
fix: compile iOS

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -118,8 +118,8 @@ export default function App() {
         radius={10}
         disabled={disabled}
         allowedPaymentMethods={googlePayRequest.allowedPaymentMethods}
-        theme={GooglePayButtonConstants.Themes.Light}
-        type={GooglePayButtonConstants.Types.Donate}
+        theme={GooglePayButtonConstants!.Themes.Light}
+        type={GooglePayButtonConstants!.Types.Donate}
       />
       <GooglePayButton
         onPress={checkCanMakePayment}
@@ -127,8 +127,8 @@ export default function App() {
         radius={150}
         disabled={!disabled}
         allowedPaymentMethods={googlePayRequest.allowedPaymentMethods}
-        theme={GooglePayButtonConstants.Themes.Dark}
-        type={GooglePayButtonConstants.Types.Buy}
+        theme={GooglePayButtonConstants!.Themes.Dark}
+        type={GooglePayButtonConstants!.Types.Buy}
       />
       <Text style={styles.text}>{text}</Text>
     </ScrollView>

--- a/src/GooglePayButton.tsx
+++ b/src/GooglePayButton.tsx
@@ -69,6 +69,6 @@ const styles = StyleSheet.create({
   },
 });
 
-const GooglePayButtonConstants = GooglePayButtonConstantsModule.loadConstants();
+const GooglePayButtonConstants = GooglePayButtonConstantsModule?.loadConstants();
 
 export { GooglePayButton, GooglePayButtonConstants };

--- a/src/specs/NativeGooglePayButtonConstantsModule.ts
+++ b/src/specs/NativeGooglePayButtonConstantsModule.ts
@@ -19,7 +19,7 @@ export interface Constants {
 }
 
 export interface Spec extends TurboModule {
-  loadConstants(): Constants;
+  loadConstants(): Constants | null;
 }
 
 export default (


### PR DESCRIPTION
Hey @stephenmcd 

When this package is built against an iOS device it fails due to the `GooglePayButtonConstantsModule` not existing (which makes sense - it's an iOS device). This however blocks my application being built for and on iOS devices.

This PR corrects the `GooglePayButtonConstants` type to be nullable as the native type is and nullifies the `GooglePayButtonConstantsModule` so it can be built correctly on iOS.

Fixes #60 