### PR TITLE
fix(android): correct @ReactProp name for button type prop

### DIFF
--- a/android/src/main/java/com/makepayment/GooglePayButtonComponentManager.kt
+++ b/android/src/main/java/com/makepayment/GooglePayButtonComponentManager.kt
@@ -31,7 +31,7 @@ class GooglePayButtonComponentManager(context: ReactApplicationContext) : Simple
     view?.allowedPaymentMethods = value!!
   }
 
-  @ReactProp(name = "buttonType")
+  @ReactProp(name = "type")
   override fun setType(view: GooglePayButtonComponent, type: Int) {
     view.type = type
   }


### PR DESCRIPTION
## Problem
The `type` prop on `GooglePayButton` was silently ignored on Android, causing
the button to always render as "Buy with Google Pay" regardless of the value
passed (e.g. `GooglePayButtonConstants.Types.Pay`).
The `theme` and `radius` props worked correctly.
## Root Cause
In `GooglePayButtonComponentManager.kt`, the `@ReactProp` annotation for the
`setType` method declared the prop name as `"buttonType"` instead of `"type"`:
```kotlin
// Before (broken)
@ReactProp(name = "buttonType")
override fun setType(view: GooglePayButtonComponent, type: Int) { ... }
